### PR TITLE
Backend updates

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -41,6 +41,8 @@
     "drupal/google_analytics": "^3.1",
     "drupal/honeypot": "^2.0",
     "drupal/image_style_quality": "^1.4",
+    "drupal/jsonapi_extras": "^3.17",
+    "drupal/jsonapi_include": "^1.4",
     "drupal/layout_builder_browser": "^1.1",
     "drupal/layout_builder_iframe_modal": "^1.0",
     "drupal/media_entity_facebook": "^2.0",

--- a/drupal/composer.lock
+++ b/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8650f110f328a2ef41286779b25e79c3",
+    "content-hash": "de56abe8e098ba9387ce0cc776580c3f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3063,6 +3063,117 @@
             }
         },
         {
+            "name": "drupal/jsonapi_extras",
+            "version": "3.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/jsonapi_extras.git",
+                "reference": "8.x-3.17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/jsonapi_extras-8.x-3.17.zip",
+                "reference": "8.x-3.17",
+                "shasum": "2795865d847212f5b465445342118c1a6f57999e"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9",
+                "drupal/jsonapi": "*",
+                "e0ipso/shaper": "^1"
+            },
+            "require-dev": {
+                "drupal/jsonapi": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-3.17",
+                    "datestamp": "1613848645",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Mateu Aguiló Bosch",
+                    "homepage": "https://www.drupal.org/user/3366066",
+                    "email": "mateu.aguilo.bosch@gmail.com"
+                },
+                {
+                    "name": "Martin Kolar",
+                    "homepage": "https://www.drupal.org/u/mkolar"
+                },
+                {
+                    "name": "Karel Majzlik",
+                    "homepage": "https://www.drupal.org/u/karlos007"
+                },
+                {
+                    "name": "Björn Brala",
+                    "homepage": "https://www.drupal.org/u/bbrala"
+                }
+            ],
+            "description": "JSON:API Extras provides a means to override and provide limited configurations to the default zero-configuration implementation provided by the JSON:API module.",
+            "homepage": "https://www.drupal.org/project/jsonapi_extras",
+            "support": {
+                "source": "https://git.drupalcode.org/project/jsonapi_extras"
+            }
+        },
+        {
+            "name": "drupal/jsonapi_include",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/jsonapi_include.git",
+                "reference": "8.x-1.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/jsonapi_include-8.x-1.4.zip",
+                "reference": "8.x-1.4",
+                "shasum": "82f370bfd826011c6d5c24dd01255bbba7552d7d"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9",
+                "drupal/jsonapi": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.4",
+                    "datestamp": "1591157629",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "zipme_hkt",
+                    "homepage": "https://www.drupal.org/user/368236"
+                }
+            ],
+            "description": "Add include data to json output",
+            "homepage": "https://www.drupal.org/project/jsonapi_include",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/jsonapi_include",
+                "issues": "https://www.drupal.org/project/issues/jsonapi_include"
+            }
+        },
+        {
             "name": "drupal/layout_builder_browser",
             "version": "1.2.0",
             "source": {
@@ -4749,6 +4860,52 @@
             "time": "2021-02-15T20:26:00+00:00"
         },
         {
+            "name": "e0ipso/shaper",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/e0ipso/shaper.git",
+                "reference": "04e17ee682d1a66726378d7d2c2a9a9b4d6984eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/e0ipso/shaper/zipball/04e17ee682d1a66726378d7d2c2a9a9b4d6984eb",
+                "reference": "04e17ee682d1a66726378d7d2c2a9a9b4d6984eb",
+                "shasum": ""
+            },
+            "require": {
+                "justinrainbow/json-schema": "^5.2"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpcov": "^5.0",
+                "phpunit/phpunit": "^7.0.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Shaper\\": "src",
+                    "Shaper\\Tests\\": "tests/src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Mateu Aguiló Bosch",
+                    "email": "mateu.aguilo.bosch@gmail.com"
+                }
+            ],
+            "description": "Lightweight library to handle in and out transformations in PHP.",
+            "support": {
+                "issues": "https://github.com/e0ipso/shaper/issues",
+                "source": "https://github.com/e0ipso/shaper/tree/1.2.3"
+            },
+            "time": "2019-07-27T10:13:44+00:00"
+        },
+        {
             "name": "easyrdf/easyrdf",
             "version": "0.9.1",
             "source": {
@@ -5397,6 +5554,76 @@
                 "source": "https://github.com/J7mbo/twitter-api-php/tree/master"
             },
             "time": "2017-05-08T12:10:56+00:00"
+        },
+        {
+            "name": "justinrainbow/json-schema",
+            "version": "5.2.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/justinrainbow/json-schema.git",
+                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
+                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
+                "json-schema/json-schema-test-suite": "1.2.0",
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/justinrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "support": {
+                "issues": "https://github.com/justinrainbow/json-schema/issues",
+                "source": "https://github.com/justinrainbow/json-schema/tree/5.2.10"
+            },
+            "time": "2020-05-27T16:41:55+00:00"
         },
         {
             "name": "kint-php/kint",
@@ -10695,76 +10922,6 @@
                 "source": "https://github.com/jcalderonzumba/MinkPhantomJSDriver/tree/master"
             },
             "time": "2016-12-01T10:57:30+00:00"
-        },
-        {
-            "name": "justinrainbow/json-schema",
-            "version": "5.2.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
-                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
-                "json-schema/json-schema-test-suite": "1.2.0",
-                "phpunit/phpunit": "^4.8.35"
-            },
-            "bin": [
-                "bin/validate-json"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "JsonSchema\\": "src/JsonSchema/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bruno Prieto Reis",
-                    "email": "bruno.p.reis@gmail.com"
-                },
-                {
-                    "name": "Justin Rainbow",
-                    "email": "justin.rainbow@gmail.com"
-                },
-                {
-                    "name": "Igor Wiedler",
-                    "email": "igor@wiedler.ch"
-                },
-                {
-                    "name": "Robert Schönthal",
-                    "email": "seroscho@googlemail.com"
-                }
-            ],
-            "description": "A library to validate a json schema.",
-            "homepage": "https://github.com/justinrainbow/json-schema",
-            "keywords": [
-                "json",
-                "schema"
-            ],
-            "support": {
-                "issues": "https://github.com/justinrainbow/json-schema/issues",
-                "source": "https://github.com/justinrainbow/json-schema/tree/5.2.10"
-            },
-            "time": "2020-05-27T16:41:55+00:00"
         },
         {
             "name": "mikey179/vfsstream",

--- a/drupal/composer.patches.json
+++ b/drupal/composer.patches.json
@@ -10,6 +10,12 @@
     },
     "drupal/media_entity_instagram": {
       "https://www.drupal.org/node/3118095": "https://www.drupal.org/files/issues/2020-09-03/3118095-10.patch"
+    },
+    "drupal/jsonapi_extras": {
+      "https://www.drupal.org/node/2942851": "https://www.drupal.org/files/issues/2021-01-06/jsonapi_extras-url_link_enhancer-2942851-38.patch"
+    },
+    "drupal/paragraphs": {
+      "https://www.drupal.org/node/2901390": "https://www.drupal.org/files/issues/2020-06-25/paragraphs-2901390-51.patch"
     }
   }
 }

--- a/drupal/config/dev/core.extension.yml
+++ b/drupal/config/dev/core.extension.yml
@@ -19,6 +19,7 @@ module:
   dblog: 0
   devel: 0
   editor: 0
+  entity_reference_revisions: 0
   environment_indicator: 0
   field: 0
   field_ui: 0
@@ -29,6 +30,9 @@ module:
   image_style_quality: 0
   inline_form_errors: 0
   jsonapi: 0
+  jsonapi_defaults: 0
+  jsonapi_extras: 0
+  jsonapi_include: 0
   layout_builder: 0
   layout_builder_browser: 0
   layout_builder_iframe_modal: 0
@@ -74,6 +78,7 @@ module:
   pathauto: 1
   xmlsitemap: 1
   views: 10
+  paragraphs: 11
   bloom: 1000
 theme:
   stable: 0

--- a/drupal/config/sync/block_content.type.button_list.yml
+++ b/drupal/config/sync/block_content.type.button_list.yml
@@ -1,0 +1,8 @@
+uuid: 9e9c1e63-5c25-4ff2-9bc4-dd8c480c1d64
+langcode: en
+status: true
+dependencies: {  }
+id: button_list
+label: 'Button list'
+revision: 0
+description: 'Block used by Layout Builder to add a Button List component.'

--- a/drupal/config/sync/block_content.type.card.yml
+++ b/drupal/config/sync/block_content.type.card.yml
@@ -1,0 +1,8 @@
+uuid: 39b670ce-4710-4432-a5ff-7b5a3990a1bd
+langcode: en
+status: true
+dependencies: {  }
+id: card
+label: 'Content Card'
+revision: 0
+description: 'Block used by Layout Builder to add a Content Card component.'

--- a/drupal/config/sync/core.entity_form_display.block_content.basic_block.default.yml
+++ b/drupal/config/sync/core.entity_form_display.block_content.basic_block.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - block_content.type.basic_block
     - field.field.block_content.basic_block.body
+    - field.field.block_content.basic_block.field_heading_level
     - field.field.block_content.basic_block.field_title
   module:
     - text
@@ -15,13 +16,19 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 1
+    weight: 2
     settings:
       rows: 9
       summary_rows: 3
       placeholder: ''
       show_summary: false
     third_party_settings: {  }
+    region: content
+  field_heading_level:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
     region: content
   field_title:
     weight: 0

--- a/drupal/config/sync/core.entity_form_display.block_content.button_list.default.yml
+++ b/drupal/config/sync/core.entity_form_display.block_content.button_list.default.yml
@@ -1,0 +1,51 @@
+uuid: 97b6afe9-2f99-4c70-b98b-06039a51cb32
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.button_list
+    - field.field.block_content.button_list.field_file_link_unlimited
+    - field.field.block_content.button_list.field_heading_level
+    - field.field.block_content.button_list.field_title
+  module:
+    - paragraphs
+id: block_content.button_list.default
+targetEntityType: block_content
+bundle: button_list
+mode: default
+content:
+  field_file_link_unlimited:
+    type: paragraphs
+    weight: 2
+    settings:
+      title: Button
+      title_plural: Buttons
+      edit_mode: closed
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: button
+      form_display_mode: default
+      default_paragraph_type: _none
+      features:
+        add_above: '0'
+        collapse_edit_all: '0'
+        duplicate: '0'
+    third_party_settings: {  }
+    region: content
+  field_heading_level:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  info: true

--- a/drupal/config/sync/core.entity_form_display.block_content.card.default.yml
+++ b/drupal/config/sync/core.entity_form_display.block_content.card.default.yml
@@ -1,0 +1,72 @@
+uuid: a1a1214a-55ab-4888-a2a4-9714d77a9a1d
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.card
+    - field.field.block_content.card.body
+    - field.field.block_content.card.field_file_link
+    - field.field.block_content.card.field_heading_level
+    - field.field.block_content.card.field_image
+    - field.field.block_content.card.field_title
+  module:
+    - media_library
+    - paragraphs
+    - text
+id: block_content.card.default
+targetEntityType: block_content
+bundle: card
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 3
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+    region: content
+  field_file_link:
+    type: paragraphs
+    weight: 4
+    settings:
+      title: CTA
+      title_plural: 'CTA''s'
+      edit_mode: closed
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: button
+      form_display_mode: default
+      default_paragraph_type: _none
+      features:
+        add_above: '0'
+        collapse_edit_all: '0'
+        duplicate: '0'
+    third_party_settings: {  }
+    region: content
+  field_heading_level:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_image:
+    type: media_library_widget
+    weight: 2
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    region: content
+  field_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  info: true

--- a/drupal/config/sync/core.entity_form_display.paragraph.file.default.yml
+++ b/drupal/config/sync/core.entity_form_display.paragraph.file.default.yml
@@ -1,0 +1,24 @@
+uuid: c13bdb82-dc8c-43d1-b4f4-071259001c70
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.file.field_file
+    - paragraphs.paragraphs_type.file
+  module:
+    - media_library
+id: paragraph.file.default
+targetEntityType: paragraph
+bundle: file
+mode: default
+content:
+  field_file:
+    type: media_library_widget
+    weight: 0
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  status: true

--- a/drupal/config/sync/core.entity_form_display.paragraph.link.default.yml
+++ b/drupal/config/sync/core.entity_form_display.paragraph.link.default.yml
@@ -1,0 +1,25 @@
+uuid: 606290fa-e4a2-49a7-acbe-5fc2ba07b0e7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.link.field_link
+    - paragraphs.paragraphs_type.link
+  module:
+    - link
+id: paragraph.link.default
+targetEntityType: paragraph
+bundle: link
+mode: default
+content:
+  field_link:
+    weight: 0
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+hidden:
+  created: true
+  status: true

--- a/drupal/config/sync/core.entity_view_display.block_content.basic_block.default.yml
+++ b/drupal/config/sync/core.entity_view_display.block_content.basic_block.default.yml
@@ -5,8 +5,10 @@ dependencies:
   config:
     - block_content.type.basic_block
     - field.field.block_content.basic_block.body
+    - field.field.block_content.basic_block.field_heading_level
     - field.field.block_content.basic_block.field_title
   module:
+    - options
     - text
 id: block_content.basic_block.default
 targetEntityType: block_content
@@ -19,6 +21,13 @@ content:
     weight: 1
     settings: {  }
     third_party_settings: {  }
+    region: content
+  field_heading_level:
+    weight: 2
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
     region: content
   field_title:
     weight: 0

--- a/drupal/config/sync/core.entity_view_display.block_content.button_list.default.yml
+++ b/drupal/config/sync/core.entity_view_display.block_content.button_list.default.yml
@@ -1,0 +1,42 @@
+uuid: c833891f-f602-420e-9027-d1e0fa8ec466
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.button_list
+    - field.field.block_content.button_list.field_file_link_unlimited
+    - field.field.block_content.button_list.field_heading_level
+    - field.field.block_content.button_list.field_title
+  module:
+    - entity_reference_revisions
+    - options
+id: block_content.button_list.default
+targetEntityType: block_content
+bundle: button_list
+mode: default
+content:
+  field_file_link_unlimited:
+    type: entity_reference_revisions_entity_view
+    weight: 0
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_heading_level:
+    weight: 2
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_title:
+    weight: 1
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/drupal/config/sync/core.entity_view_display.block_content.card.default.yml
+++ b/drupal/config/sync/core.entity_view_display.block_content.card.default.yml
@@ -1,0 +1,61 @@
+uuid: 5dd361bd-9276-445d-9c12-cacf785ac91e
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.card
+    - field.field.block_content.card.body
+    - field.field.block_content.card.field_file_link
+    - field.field.block_content.card.field_heading_level
+    - field.field.block_content.card.field_image
+    - field.field.block_content.card.field_title
+  module:
+    - entity_reference_revisions
+    - options
+    - text
+id: block_content.card.default
+targetEntityType: block_content
+bundle: card
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_file_link:
+    type: entity_reference_revisions_entity_view
+    weight: 3
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_heading_level:
+    weight: 2
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_image:
+    type: entity_reference_entity_view
+    weight: 4
+    label: above
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_title:
+    weight: 1
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/drupal/config/sync/core.entity_view_display.paragraph.file.default.yml
+++ b/drupal/config/sync/core.entity_view_display.paragraph.file.default.yml
@@ -1,0 +1,22 @@
+uuid: de453322-2d8f-4255-b42b-0c299af2b028
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.file.field_file
+    - paragraphs.paragraphs_type.file
+id: paragraph.file.default
+targetEntityType: paragraph
+bundle: file
+mode: default
+content:
+  field_file:
+    type: entity_reference_entity_view
+    weight: 0
+    label: above
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/drupal/config/sync/core.entity_view_display.paragraph.link.default.yml
+++ b/drupal/config/sync/core.entity_view_display.paragraph.link.default.yml
@@ -1,0 +1,27 @@
+uuid: d1adaca2-0b63-4f12-a1f5-20cc384e3dce
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.link.field_link
+    - paragraphs.paragraphs_type.link
+  module:
+    - link
+id: paragraph.link.default
+targetEntityType: paragraph
+bundle: link
+mode: default
+content:
+  field_link:
+    weight: 0
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+hidden: {  }

--- a/drupal/config/sync/core.extension.yml
+++ b/drupal/config/sync/core.extension.yml
@@ -18,6 +18,7 @@ module:
   datetime_range: 0
   dblog: 0
   editor: 0
+  entity_reference_revisions: 0
   environment_indicator: 0
   field: 0
   field_ui: 0
@@ -28,6 +29,9 @@ module:
   image_style_quality: 0
   inline_form_errors: 0
   jsonapi: 0
+  jsonapi_defaults: 0
+  jsonapi_extras: 0
+  jsonapi_include: 0
   layout_builder: 0
   layout_builder_browser: 0
   layout_builder_iframe_modal: 0
@@ -71,6 +75,7 @@ module:
   pathauto: 1
   xmlsitemap: 1
   views: 10
+  paragraphs: 11
   bloom: 1000
 theme:
   stable: 0

--- a/drupal/config/sync/field.field.block_content.basic_block.field_heading_level.yml
+++ b/drupal/config/sync/field.field.block_content.basic_block.field_heading_level.yml
@@ -1,0 +1,23 @@
+uuid: 17ecd396-1646-4b0f-b19a-aa5aaa914241
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic_block
+    - field.storage.block_content.field_heading_level
+  module:
+    - options
+id: block_content.basic_block.field_heading_level
+field_name: field_heading_level
+entity_type: block_content
+bundle: basic_block
+label: 'Heading level'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: h2
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/drupal/config/sync/field.field.block_content.button_list.field_file_link_unlimited.yml
+++ b/drupal/config/sync/field.field.block_content.button_list.field_file_link_unlimited.yml
@@ -1,0 +1,36 @@
+uuid: 5eef31d8-8b8d-4c7c-b883-4d66052c0f72
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.button_list
+    - field.storage.block_content.field_file_link_unlimited
+    - paragraphs.paragraphs_type.file
+    - paragraphs.paragraphs_type.link
+  module:
+    - entity_reference_revisions
+id: block_content.button_list.field_file_link_unlimited
+field_name: field_file_link_unlimited
+entity_type: block_content
+bundle: button_list
+label: Buttons
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      file: file
+      link: link
+    target_bundles_drag_drop:
+      file:
+        enabled: true
+        weight: 3
+      link:
+        enabled: true
+        weight: 4
+field_type: entity_reference_revisions

--- a/drupal/config/sync/field.field.block_content.button_list.field_heading_level.yml
+++ b/drupal/config/sync/field.field.block_content.button_list.field_heading_level.yml
@@ -1,0 +1,23 @@
+uuid: 44a24749-924b-410c-abe5-698d7e4044bb
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.button_list
+    - field.storage.block_content.field_heading_level
+  module:
+    - options
+id: block_content.button_list.field_heading_level
+field_name: field_heading_level
+entity_type: block_content
+bundle: button_list
+label: 'Heading level'
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: h2
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/drupal/config/sync/field.field.block_content.button_list.field_title.yml
+++ b/drupal/config/sync/field.field.block_content.button_list.field_title.yml
@@ -1,0 +1,19 @@
+uuid: 104a8499-29e0-4cb0-8b2a-5b2863b0c4ef
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.button_list
+    - field.storage.block_content.field_title
+id: block_content.button_list.field_title
+field_name: field_title
+entity_type: block_content
+bundle: button_list
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/drupal/config/sync/field.field.block_content.card.body.yml
+++ b/drupal/config/sync/field.field.block_content.card.body.yml
@@ -1,0 +1,23 @@
+uuid: 6ad2adf7-4bd7-4ee3-9aab-76ba6deb9e9e
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.card
+    - field.storage.block_content.body
+  module:
+    - text
+id: block_content.card.body
+field_name: body
+entity_type: block_content
+bundle: card
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/drupal/config/sync/field.field.block_content.card.field_file_link.yml
+++ b/drupal/config/sync/field.field.block_content.card.field_file_link.yml
@@ -1,0 +1,36 @@
+uuid: d2568ca6-230b-4b95-b444-b824c928da73
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.card
+    - field.storage.block_content.field_file_link
+    - paragraphs.paragraphs_type.file
+    - paragraphs.paragraphs_type.link
+  module:
+    - entity_reference_revisions
+id: block_content.card.field_file_link
+field_name: field_file_link
+entity_type: block_content
+bundle: card
+label: CTA
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      file: file
+      link: link
+    target_bundles_drag_drop:
+      file:
+        enabled: true
+        weight: 3
+      link:
+        enabled: true
+        weight: 4
+field_type: entity_reference_revisions

--- a/drupal/config/sync/field.field.block_content.card.field_heading_level.yml
+++ b/drupal/config/sync/field.field.block_content.card.field_heading_level.yml
@@ -1,0 +1,23 @@
+uuid: 0caf092e-7530-4c94-abb7-60b12e777b39
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.card
+    - field.storage.block_content.field_heading_level
+  module:
+    - options
+id: block_content.card.field_heading_level
+field_name: field_heading_level
+entity_type: block_content
+bundle: card
+label: 'Heading level'
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: h2
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/drupal/config/sync/field.field.block_content.card.field_image.yml
+++ b/drupal/config/sync/field.field.block_content.card.field_image.yml
@@ -1,0 +1,28 @@
+uuid: 950742f6-093a-44e4-9a8a-82f62c8641ac
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.card
+    - field.storage.block_content.field_image
+    - media.type.image
+id: block_content.card.field_image
+field_name: field_image
+entity_type: block_content
+bundle: card
+label: Image
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/drupal/config/sync/field.field.block_content.card.field_title.yml
+++ b/drupal/config/sync/field.field.block_content.card.field_title.yml
@@ -1,0 +1,19 @@
+uuid: ab6fc392-7391-452b-82de-58cb0b86d670
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.card
+    - field.storage.block_content.field_title
+id: block_content.card.field_title
+field_name: field_title
+entity_type: block_content
+bundle: card
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/drupal/config/sync/field.field.paragraph.file.field_file.yml
+++ b/drupal/config/sync/field.field.paragraph.file.field_file.yml
@@ -1,0 +1,28 @@
+uuid: cc012378-4ec5-4ac6-b3fe-eecee39f690d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_file
+    - media.type.file
+    - paragraphs.paragraphs_type.file
+id: paragraph.file.field_file
+field_name: field_file
+entity_type: paragraph
+bundle: file
+label: File
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      file: file
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/drupal/config/sync/field.field.paragraph.link.field_link.yml
+++ b/drupal/config/sync/field.field.paragraph.link.field_link.yml
@@ -1,0 +1,23 @@
+uuid: b07f826d-c02a-4e76-9dab-fab8be64374e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_link
+    - paragraphs.paragraphs_type.link
+  module:
+    - link
+id: paragraph.link.field_link
+field_name: field_link
+entity_type: paragraph
+bundle: link
+label: Link
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 2
+field_type: link

--- a/drupal/config/sync/field.storage.block_content.field_file_link.yml
+++ b/drupal/config/sync/field.storage.block_content.field_file_link.yml
@@ -1,0 +1,21 @@
+uuid: 12757040-e041-4175-b468-b5ae110c7fe3
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - entity_reference_revisions
+    - paragraphs
+id: block_content.field_file_link
+field_name: field_file_link
+entity_type: block_content
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/drupal/config/sync/field.storage.block_content.field_file_link_unlimited.yml
+++ b/drupal/config/sync/field.storage.block_content.field_file_link_unlimited.yml
@@ -1,0 +1,21 @@
+uuid: b756a4f5-be44-47b2-aed9-391f05e36b41
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - entity_reference_revisions
+    - paragraphs
+id: block_content.field_file_link_unlimited
+field_name: field_file_link_unlimited
+entity_type: block_content
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/drupal/config/sync/field.storage.block_content.field_heading_level.yml
+++ b/drupal/config/sync/field.storage.block_content.field_heading_level.yml
@@ -1,0 +1,30 @@
+uuid: ce670407-4229-4f81-b7cd-0a72d953429a
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - options
+id: block_content.field_heading_level
+field_name: field_heading_level
+entity_type: block_content
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: h1
+      label: H1
+    -
+      value: h2
+      label: H2
+    -
+      value: h3
+      label: H3
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/drupal/config/sync/field.storage.block_content.field_image.yml
+++ b/drupal/config/sync/field.storage.block_content.field_image.yml
@@ -1,0 +1,20 @@
+uuid: 7c3df6f3-1338-4d12-bf70-165ce8447de0
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - media
+id: block_content.field_image
+field_name: field_image
+entity_type: block_content
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/drupal/config/sync/field.storage.paragraph.field_file.yml
+++ b/drupal/config/sync/field.storage.paragraph.field_file.yml
@@ -1,0 +1,20 @@
+uuid: 5091aff9-0a17-4089-862d-2426a0a64bf9
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - paragraphs
+id: paragraph.field_file
+field_name: field_file
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/drupal/config/sync/field.storage.paragraph.field_link.yml
+++ b/drupal/config/sync/field.storage.paragraph.field_link.yml
@@ -1,0 +1,19 @@
+uuid: 11cebca2-360d-4e94-b7aa-3ff91f93237a
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_link
+field_name: field_link
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/drupal/config/sync/jsonapi_extras.jsonapi_resource_config.node--landing_page.yml
+++ b/drupal/config/sync/jsonapi_extras.jsonapi_resource_config.node--landing_page.yml
@@ -1,0 +1,158 @@
+uuid: ffb489b5-179d-4782-9c41-e9cb89ade56c
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.landing_page
+  module:
+    - jsonapi_defaults
+third_party_settings:
+  jsonapi_defaults:
+    default_include:
+      - field_blocks.field_image.field_media_image
+      - 'field_blocks. field_file_link_unlimited.field_file.field_media_file'
+      - 'field_blocks. field_file_link.field_file.field_media_file'
+    page_limit: 50
+id: node--landing_page
+disabled: false
+path: node/landing_page
+resourceType: node--landing_page
+resourceFields:
+  nid:
+    fieldName: nid
+    publicName: nid
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false
+  vid:
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  type:
+    fieldName: type
+    publicName: type
+    enhancer:
+      id: ''
+    disabled: false
+  revision_timestamp:
+    fieldName: revision_timestamp
+    publicName: revision_timestamp
+    enhancer:
+      id: ''
+    disabled: false
+  revision_uid:
+    fieldName: revision_uid
+    publicName: revision_uid
+    enhancer:
+      id: ''
+    disabled: false
+  revision_log:
+    fieldName: revision_log
+    publicName: revision_log
+    enhancer:
+      id: ''
+    disabled: false
+  status:
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+    disabled: false
+  uid:
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+    disabled: false
+  title:
+    fieldName: title
+    publicName: title
+    enhancer:
+      id: ''
+    disabled: false
+  created:
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+    disabled: false
+  changed:
+    fieldName: changed
+    publicName: changed
+    enhancer:
+      id: ''
+    disabled: false
+  promote:
+    fieldName: promote
+    publicName: promote
+    enhancer:
+      id: ''
+    disabled: false
+  sticky:
+    fieldName: sticky
+    publicName: sticky
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  revision_default:
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+    disabled: false
+  revision_translation_affected:
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+    disabled: false
+  metatag:
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+    disabled: false
+  path:
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+    disabled: false
+  menu_link:
+    fieldName: menu_link
+    publicName: menu_link
+    enhancer:
+      id: ''
+    disabled: false
+  field_blocks:
+    fieldName: field_blocks
+    publicName: field_blocks
+    enhancer:
+      id: ''
+    disabled: false
+  layout_builder__layout:
+    fieldName: layout_builder__layout
+    publicName: layout_builder__layout
+    enhancer:
+      id: ''
+    disabled: false

--- a/drupal/config/sync/jsonapi_extras.settings.yml
+++ b/drupal/config/sync/jsonapi_extras.settings.yml
@@ -1,0 +1,4 @@
+path_prefix: jsonapi
+include_count: false
+_core:
+  default_config_hash: eZ7KZ6nM56SRhfriFWCo1372Z9UiKufhSLRbkdhVmUg

--- a/drupal/config/sync/jsonapi_include.settings.yml
+++ b/drupal/config/sync/jsonapi_include.settings.yml
@@ -1,0 +1,1 @@
+use_include_query: 0

--- a/drupal/config/sync/layout_builder_browser.layout_builder_browser_block.button_list.yml
+++ b/drupal/config/sync/layout_builder_browser.layout_builder_browser_block.button_list.yml
@@ -1,0 +1,11 @@
+uuid: 4bdbe107-3a72-4419-acba-e96b9f264dba
+langcode: en
+status: true
+dependencies: {  }
+id: button_list
+block_id: 'inline_block:button_list'
+category: components
+label: 'Button list'
+weight: 1
+image_path: ''
+image_alt: ''

--- a/drupal/config/sync/layout_builder_browser.layout_builder_browser_block.content_card.yml
+++ b/drupal/config/sync/layout_builder_browser.layout_builder_browser_block.content_card.yml
@@ -1,0 +1,11 @@
+uuid: 03edd6cd-887d-41c6-8bf9-587a63024fc7
+langcode: en
+status: true
+dependencies: {  }
+id: content_card
+block_id: 'inline_block:card'
+category: components
+label: 'Content card'
+weight: 0
+image_path: ''
+image_alt: ''

--- a/drupal/config/sync/paragraphs.paragraphs_type.file.yml
+++ b/drupal/config/sync/paragraphs.paragraphs_type.file.yml
@@ -1,0 +1,10 @@
+uuid: 31adfa3c-bfa5-4d91-89a8-ddd8bcf349e3
+langcode: en
+status: true
+dependencies: {  }
+id: file
+label: File
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/drupal/config/sync/paragraphs.paragraphs_type.link.yml
+++ b/drupal/config/sync/paragraphs.paragraphs_type.link.yml
@@ -1,0 +1,10 @@
+uuid: b023e320-e9d7-4242-94a7-45e0072f1552
+langcode: en
+status: true
+dependencies: {  }
+id: link
+label: Link
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/drupal/config/sync/paragraphs.settings.yml
+++ b/drupal/config/sync/paragraphs.settings.yml
@@ -1,0 +1,3 @@
+show_unpublished: true
+_core:
+  default_config_hash: 7eR0sk71Eol86r_A7BMqn5_46wzenh5J1O5vZRCGKv8


### PR DESCRIPTION
- Install and enable `jsonapi_extras`, `jsonapi_include` and `paragraph` modules
- Add "Content card" and "Button list" block types
- Configure default includes in jsonapi landing page resource

## How to test

- [ ] In the drupal folder, run `composer install && chirripo drush cim -- -y && chirripo drush cr`
- [ ] Create a new landing page. You should be able to add blocks of type "Content card" and "Button list". Add at least one block of each type. Add at least one file in the button list or content card CTA
- [ ] Using an API browser, visit http://drupal-nextjs.docker/jsonapi/node/landing_page. Confirm that all the data (blocks and paragraph) is present in the JSON response
